### PR TITLE
remove ts files in package when publish

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,9 @@
+.github
+
+CODE_OF_CONDUCT.md
+
+.eslintrc.js
+.prettierrc
+tsconfig.json
+
+src/**/*.ts

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-animal",
-  "version": "0.0.26",
+  "version": "0.0.28",
   "description": "",
   "main": "src/index.ts",
   "scripts": {

--- a/readme.md
+++ b/readme.md
@@ -49,6 +49,12 @@ $ ts-animal tiger --repeat=3 --speed=1800
 - make frames as text files in zoo folder. No matter txt files name, but make sure files name and frames are sorted. 
 - please check first npx run list, to prevent duplicated name.
 
+## How to publish
+
+```shell
+$ pnpm script:publish
+```
+
 ## Stay in touch
 E-mail - team.ts.animal@gmail.com
 


### PR DESCRIPTION
- Remove files that not involved to executable package.
   - Some files are not removed like`package.json`, `readme.md` etc... Also `index.ts` is not removed while it is used as the main. (wrritten in `package.json`)
   - ref: https://docs.npmjs.com/cli/v10/using-npm/developers

 > Additionally, everything in node_modules is ignored, except for bundled dependencies. npm automatically handles this for you, so don't bother adding node_modules to .npmignore.

 
`node_modules` are automatically insatlled by npm, so not need to be considered.

  
 ---

Published package's code screenshot.

![스크린샷 2024-01-27 오후 7 50 50](https://github.com/ts-animal/ts-animal/assets/50096419/d9533fa4-971b-403c-90b3-f281d2a4ca94)
 https://www.npmjs.com/package/ts-animal?activeTab=code


